### PR TITLE
Remove dependency on directory name, make explicit with -b.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,12 @@
-all:
-	ponyc -d .
-	./pony-ircd
+PROG = pony-ircd
+
+all:		$(PROG)
+
+$(PROG):	main.pony IrcClientSession.pony
+	ponyc -d -b $(PROG) .
+
+run:		$(PROG)
+	./$(PROG)
+
+clean:
+	rm -f *.o $(PROG)


### PR DESCRIPTION
Re Makefile:

1) Using ponyc's -b option is more robust than assuming the directory name matches (git push isn't sensitive to parent directory name changes).  My make bombed out initially because I commonly keep project names suffixed with the clone originator and other metadata.

2) I separated building and running, or it's asking for trouble.

3) Added normal boilerplate useful in Makefiles.